### PR TITLE
feat: add network erg bitsreceivedpersec alerts

### DIFF
--- a/services/Network/expressRouteGateways/Deploy-ERG-BitsReceivedPerSecond-High-Alert.json
+++ b/services/Network/expressRouteGateways/Deploy-ERG-BitsReceivedPerSecond-High-Alert.json
@@ -1,0 +1,333 @@
+{
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "apiVersion": "2021-06-01",
+    "name": "Deploy_ERGw_ExpressRouteBitsReceivedPerSecond_Alert_TooHigh",
+    "properties": {
+      "policyType": "Custom",
+      "mode": "All",
+      "displayName": "Deploy ERG ExpressRoute Bits Received Per Second Alert Too High",
+      "description": "Policy to audit/deploy Express Route Gateway Received Bits Per Second Alert Too High",
+      "metadata": {
+        "version": "1.2.0",
+        "category": "Network",
+        "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
+        "alzCloudEnvironments": [
+          "AzureCloud"
+        ],
+        "_deployed_by_amba": "True"
+      },
+      "parameters": {
+        "severity": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Severity",
+            "description": "Severity of the Alert"
+          },
+          "allowedValues": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4"
+          ],
+          "defaultValue": "0"
+        },
+        "windowSize": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Window Size",
+            "description": "Window size for the alert"
+          },
+          "allowedValues": [
+            "PT1M",
+            "PT5M",
+            "PT15M",
+            "PT30M",
+            "PT1H",
+            "PT6H",
+            "PT12H",
+            "P1D"
+          ],
+          "defaultValue": "PT5M"
+        },
+        "evaluationFrequency": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Evaluation Frequency",
+            "description": "Evaluation frequency for the alert"
+          },
+          "allowedValues": [
+            "PT1M",
+            "PT5M",
+            "PT15M",
+            "PT30M",
+            "PT1H"
+          ],
+          "defaultValue": "PT1M"
+        },
+        "autoMitigate": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Auto Mitigate",
+            "description": "Auto Mitigate for the alert"
+          },
+          "allowedValues": [
+            "true",
+            "false"
+          ],
+          "defaultValue": "true"
+        },
+        "enabled": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Alert State",
+            "description": "Alert state for the alert"
+          },
+          "allowedValues": [
+            "true",
+            "false"
+          ],
+          "defaultValue": "true"
+        },
+        "threshold": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Threshold",
+            "description": "Threshold for the alert"
+          },
+          "defaultValue": "1"
+        },
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Effect of the policy"
+          },
+          "allowedValues": [
+            "deployIfNotExists",
+            "disabled"
+          ],
+          "defaultValue": "deployIfNotExists"
+        },
+        "MonitorDisableTagName": {
+          "type": "String",
+          "metadata": {
+            "displayName": "ALZ Monitoring disabled tag name",
+            "description": "Tag name used to disable monitoring at the resource level. Set to true if monitoring should be disabled."
+          },
+          "defaultValue": "MonitorDisable"
+        },
+        "MonitorDisableTagValues": {
+          "type": "Array",
+          "metadata": {
+            "displayName": "ALZ Monitoring disabled tag values(s)",
+            "description": "Tag value(s) used to disable monitoring at the resource level. Set to true if monitoring should be disabled."
+          },
+          "defaultValue": [
+            "true",
+            "Test",
+            "Dev",
+            "Sandbox"
+          ]
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Network/expressroutegateways"
+            },
+            {
+              "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
+              "notIn": "[[parameters('MonitorDisableTagValues')]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[[parameters('effect')]",
+          "details": {
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+            ],
+            "type": "Microsoft.Insights/metricAlerts",
+            "existenceCondition": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricNamespace",
+                  "equals": "Microsoft.Network/expressroutegateways"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricName",
+                  "equals": "ExpressRouteGatewayBitsPerSecond"
+                },
+                {
+                  "field": "Microsoft.Insights/metricalerts/scopes[*]",
+                  "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressroutegateways/', field('fullName'))]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/enabled",
+                  "equals": "[[parameters('enabled')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/evaluationFrequency",
+                  "equals": "[[parameters('evaluationFrequency')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/windowSize",
+                  "equals": "[[parameters('windowSize')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricalerts/severity",
+                  "equals": "[[parameters('severity')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/autoMitigate",
+                  "equals": "[[parameters('autoMitigate')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
+                  "equals": "Average"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].operator",
+                  "equals": "GreaterThan"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].threshold",
+                  "equals": "[[if(contains(field('tags'), '_amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), parameters('threshold'))]"
+                }
+              ]
+            },
+            "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "resourceName": {
+                      "type": "String",
+                      "metadata": {
+                        "displayName": "resourceName",
+                        "description": "Name of the resource"
+                      }
+                    },
+                    "resourceId": {
+                      "type": "String",
+                      "metadata": {
+                        "displayName": "resourceId",
+                        "description": "Resource ID of the resource emitting the metric that will be used for the comparison"
+                      }
+                    },
+                    "severity": {
+                      "type": "String"
+                    },
+                    "windowSize": {
+                      "type": "String"
+                    },
+                    "evaluationFrequency": {
+                      "type": "String"
+                    },
+                    "autoMitigate": {
+                      "type": "String"
+                    },
+                    "enabled": {
+                      "type": "String"
+                    },
+                    "threshold": {
+                      "type": "String"
+                    }
+                  },
+                  "variables": {},
+                  "resources": [
+                    {
+                      "type": "Microsoft.Insights/metricAlerts",
+                      "apiVersion": "2018-03-01",
+                      "name": "[[concat(parameters('resourceName'), '-GatewayERBitsAlert')]",
+                      "location": "global",
+                      "tags": {
+                        "_deployed_by_amba": true
+                      },
+                      "properties": {
+                        "description": "Metric Alert for Express Route Gateway Received Bits Per Second Too High",
+                        "severity": "[[parameters('severity')]",
+                        "enabled": "[[parameters('enabled')]",
+                        "scopes": [
+                          "[[parameters('resourceId')]"
+                        ],
+                        "evaluationFrequency": "[[parameters('evaluationFrequency')]",
+                        "windowSize": "[[parameters('windowSize')]",
+                        "criteria": {
+                          "allOf": [
+                            {
+                              "name": "ExpressRouteGatewayBitsPerSecond",
+                              "metricNamespace": "Microsoft.Network/expressroutegateways",
+                              "metricName": "ExpressRouteGatewayBitsPerSecond",
+                              "operator": "GreaterThan",
+                              "threshold": "[[parameters('threshold')]",
+                              "timeAggregation": "Average",
+                              "criterionType": "StaticThresholdCriterion"
+                            }
+                          ],
+                          "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                        },
+                        "autoMitigate": "[[parameters('autoMitigate')]",
+                        "parameters": {
+                          "severity": {
+                            "value": "[[parameters('severity')]"
+                          },
+                          "windowSize": {
+                            "value": "[[parameters('windowSize')]"
+                          },
+                          "evaluationFrequency": {
+                            "value": "[[parameters('evaluationFrequency')]"
+                          },
+                          "autoMitigate": {
+                            "value": "[[parameters('autoMitigate')]"
+                          },
+                          "enabled": {
+                            "value": "[[parameters('enabled')]"
+                          },
+                          "threshold": {
+                            "value": "[[parameters('threshold')]"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "parameters": {
+                  "resourceName": {
+                    "value": "[[field('name')]"
+                  },
+                  "resourceId": {
+                    "value": "[[field('id')]"
+                  },
+                  "severity": {
+                    "value": "[[parameters('severity')]"
+                  },
+                  "windowSize": {
+                    "value": "[[parameters('windowSize')]"
+                  },
+                  "evaluationFrequency": {
+                    "value": "[[parameters('evaluationFrequency')]"
+                  },
+                  "autoMitigate": {
+                    "value": "[[parameters('autoMitigate')]"
+                  },
+                  "enabled": {
+                    "value": "[[parameters('enabled')]"
+                  },
+                  "threshold": {
+                    "value": "[[if(contains(field('tags'), '_amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), parameters('threshold'))]"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  

--- a/services/Network/expressRouteGateways/Deploy-ERG-BitsReceivedPerSecond-High-Alert.json
+++ b/services/Network/expressRouteGateways/Deploy-ERG-BitsReceivedPerSecond-High-Alert.json
@@ -95,7 +95,7 @@
             "displayName": "Threshold",
             "description": "Threshold for the alert"
           },
-          "defaultValue": "1"
+          "defaultValue": "1800"
         },
         "effect": {
           "type": "String",

--- a/services/Network/expressRouteGateways/Deploy-ERG-BitsReceivedPerSecond-Low-Alert.json
+++ b/services/Network/expressRouteGateways/Deploy-ERG-BitsReceivedPerSecond-Low-Alert.json
@@ -1,0 +1,333 @@
+{
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "apiVersion": "2021-06-01",
+    "name": "Deploy_ERGw_ExpressRouteBitsReceivedPerSecond_Alert_TooLow",
+    "properties": {
+      "policyType": "Custom",
+      "mode": "All",
+      "displayName": "Deploy ERG ExpressRoute Bits Received Per Second Alert Too Low",
+      "description": "Policy to audit/deploy Express Route Gateway Received Bits Per Second Alert Too Low",
+      "metadata": {
+        "version": "1.2.0",
+        "category": "Network",
+        "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
+        "alzCloudEnvironments": [
+          "AzureCloud"
+        ],
+        "_deployed_by_amba": "True"
+      },
+      "parameters": {
+        "severity": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Severity",
+            "description": "Severity of the Alert"
+          },
+          "allowedValues": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4"
+          ],
+          "defaultValue": "0"
+        },
+        "windowSize": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Window Size",
+            "description": "Window size for the alert"
+          },
+          "allowedValues": [
+            "PT1M",
+            "PT5M",
+            "PT15M",
+            "PT30M",
+            "PT1H",
+            "PT6H",
+            "PT12H",
+            "P1D"
+          ],
+          "defaultValue": "PT5M"
+        },
+        "evaluationFrequency": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Evaluation Frequency",
+            "description": "Evaluation frequency for the alert"
+          },
+          "allowedValues": [
+            "PT1M",
+            "PT5M",
+            "PT15M",
+            "PT30M",
+            "PT1H"
+          ],
+          "defaultValue": "PT1M"
+        },
+        "autoMitigate": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Auto Mitigate",
+            "description": "Auto Mitigate for the alert"
+          },
+          "allowedValues": [
+            "true",
+            "false"
+          ],
+          "defaultValue": "true"
+        },
+        "enabled": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Alert State",
+            "description": "Alert state for the alert"
+          },
+          "allowedValues": [
+            "true",
+            "false"
+          ],
+          "defaultValue": "true"
+        },
+        "threshold": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Threshold",
+            "description": "Threshold for the alert"
+          },
+          "defaultValue": "1"
+        },
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Effect of the policy"
+          },
+          "allowedValues": [
+            "deployIfNotExists",
+            "disabled"
+          ],
+          "defaultValue": "deployIfNotExists"
+        },
+        "MonitorDisableTagName": {
+          "type": "String",
+          "metadata": {
+            "displayName": "ALZ Monitoring disabled tag name",
+            "description": "Tag name used to disable monitoring at the resource level. Set to true if monitoring should be disabled."
+          },
+          "defaultValue": "MonitorDisable"
+        },
+        "MonitorDisableTagValues": {
+          "type": "Array",
+          "metadata": {
+            "displayName": "ALZ Monitoring disabled tag values(s)",
+            "description": "Tag value(s) used to disable monitoring at the resource level. Set to true if monitoring should be disabled."
+          },
+          "defaultValue": [
+            "true",
+            "Test",
+            "Dev",
+            "Sandbox"
+          ]
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Network/expressroutegateways"
+            },
+            {
+              "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
+              "notIn": "[[parameters('MonitorDisableTagValues')]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[[parameters('effect')]",
+          "details": {
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+            ],
+            "type": "Microsoft.Insights/metricAlerts",
+            "existenceCondition": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricNamespace",
+                  "equals": "Microsoft.Network/expressroutegateways"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricName",
+                  "equals": "ExpressRouteGatewayBitsPerSecond"
+                },
+                {
+                  "field": "Microsoft.Insights/metricalerts/scopes[*]",
+                  "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressroutegateways/', field('fullName'))]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/enabled",
+                  "equals": "[[parameters('enabled')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/evaluationFrequency",
+                  "equals": "[[parameters('evaluationFrequency')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/windowSize",
+                  "equals": "[[parameters('windowSize')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricalerts/severity",
+                  "equals": "[[parameters('severity')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/autoMitigate",
+                  "equals": "[[parameters('autoMitigate')]"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
+                  "equals": "Average"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].operator",
+                  "equals": "LessThan"
+                },
+                {
+                  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].threshold",
+                  "equals": "[[if(contains(field('tags'), '_amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), parameters('threshold'))]"
+                }
+              ]
+            },
+            "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "resourceName": {
+                      "type": "String",
+                      "metadata": {
+                        "displayName": "resourceName",
+                        "description": "Name of the resource"
+                      }
+                    },
+                    "resourceId": {
+                      "type": "String",
+                      "metadata": {
+                        "displayName": "resourceId",
+                        "description": "Resource ID of the resource emitting the metric that will be used for the comparison"
+                      }
+                    },
+                    "severity": {
+                      "type": "String"
+                    },
+                    "windowSize": {
+                      "type": "String"
+                    },
+                    "evaluationFrequency": {
+                      "type": "String"
+                    },
+                    "autoMitigate": {
+                      "type": "String"
+                    },
+                    "enabled": {
+                      "type": "String"
+                    },
+                    "threshold": {
+                      "type": "String"
+                    }
+                  },
+                  "variables": {},
+                  "resources": [
+                    {
+                      "type": "Microsoft.Insights/metricAlerts",
+                      "apiVersion": "2018-03-01",
+                      "name": "[[concat(parameters('resourceName'), '-GatewayERBitsAlert')]",
+                      "location": "global",
+                      "tags": {
+                        "_deployed_by_amba": true
+                      },
+                      "properties": {
+                        "description": "Metric Alert for Express Route Gateway Received Bits Per Second Too Low",
+                        "severity": "[[parameters('severity')]",
+                        "enabled": "[[parameters('enabled')]",
+                        "scopes": [
+                          "[[parameters('resourceId')]"
+                        ],
+                        "evaluationFrequency": "[[parameters('evaluationFrequency')]",
+                        "windowSize": "[[parameters('windowSize')]",
+                        "criteria": {
+                          "allOf": [
+                            {
+                              "name": "ExpressRouteGatewayBitsPerSecond",
+                              "metricNamespace": "Microsoft.Network/expressroutegateways",
+                              "metricName": "ExpressRouteGatewayBitsPerSecond",
+                              "operator": "LessThan",
+                              "threshold": "[[parameters('threshold')]",
+                              "timeAggregation": "Average",
+                              "criterionType": "StaticThresholdCriterion"
+                            }
+                          ],
+                          "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                        },
+                        "autoMitigate": "[[parameters('autoMitigate')]",
+                        "parameters": {
+                          "severity": {
+                            "value": "[[parameters('severity')]"
+                          },
+                          "windowSize": {
+                            "value": "[[parameters('windowSize')]"
+                          },
+                          "evaluationFrequency": {
+                            "value": "[[parameters('evaluationFrequency')]"
+                          },
+                          "autoMitigate": {
+                            "value": "[[parameters('autoMitigate')]"
+                          },
+                          "enabled": {
+                            "value": "[[parameters('enabled')]"
+                          },
+                          "threshold": {
+                            "value": "[[parameters('threshold')]"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "parameters": {
+                  "resourceName": {
+                    "value": "[[field('name')]"
+                  },
+                  "resourceId": {
+                    "value": "[[field('id')]"
+                  },
+                  "severity": {
+                    "value": "[[parameters('severity')]"
+                  },
+                  "windowSize": {
+                    "value": "[[parameters('windowSize')]"
+                  },
+                  "evaluationFrequency": {
+                    "value": "[[parameters('evaluationFrequency')]"
+                  },
+                  "autoMitigate": {
+                    "value": "[[parameters('autoMitigate')]"
+                  },
+                  "enabled": {
+                    "value": "[[parameters('enabled')]"
+                  },
+                  "threshold": {
+                    "value": "[[if(contains(field('tags'), '_amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), parameters('threshold'))]"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  

--- a/services/Network/expressRouteGateways/alerts.yaml
+++ b/services/Network/expressRouteGateways/alerts.yaml
@@ -94,3 +94,67 @@
       scope: Resource
       multiResource: false
   guid: af1ba971-9b73-4b7f-8040-5eff9f5778d5
+- name: ExpressRouteGatewayBitsPerSecondGreater
+  description: Metric Too high Alert for ExpressRoute Gateway Bits Received Per Second
+  type: Metric
+  verified: false
+  visible: false
+  tags:
+  - alz
+  properties:
+    metricName: ExpressRouteGatewayBitsPerSecond
+    metricNamespace: Microsoft.Network/expressRouteGateways
+    severity: 0
+    windowSize: PT5M
+    evaluationFrequency: PT1M
+    timeAggregation: Average
+    operator: GreaterThan
+    threshold: 95
+    criterionType: StaticThresholdCriterion
+    autoMitigate: false
+    enabled: true
+  references:
+  - name: Supported metrics for Microsoft.Network/expressRouteGateways
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-network-expressroutegateways-metrics
+  deployments:
+  - name: Deploy ExpressRoute Gateway Received Bits Per Second Too High Alert
+    template: Deploy-ERG-BitsReceivedPerSecond-High-Alert.json
+    type: Policy
+    tags:
+    - alz
+    properties:
+      scope: Resource
+      multiResource: false
+  guid: 81e6a3a8-74c2-4c4d-ab7d-bc152a24ec1e
+- name: ExpressRouteGatewayBitsPerSecondTooLow
+  description: Metric Too Low Alert for ExpressRoute Gateway Bits Received Per Second
+  type: Metric
+  verified: false
+  visible: true
+  tags:
+  - alz
+  properties:
+    metricName: ExpressRouteGatewayBitsPerSecond
+    metricNamespace: Microsoft.Network/expressRouteGateways
+    severity: 0
+    windowSize: PT5M
+    evaluationFrequency: PT1M
+    timeAggregation: Average
+    operator: LessThan
+    threshold: 1
+    criterionType: StaticThresholdCriterion
+    autoMitigate: false
+    enabled: true
+  references:
+  - name: Supported metrics for Microsoft.Network/expressRouteGateways
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-network-expressroutegateways-metrics
+  deployments:
+  - name: Deploy ExpressRoute Gateway Received Bits Per Second Too Low Alert
+    template: Deploy-ERG-BitsReceivedPerSecond-Low-Alert.json
+    type: Policy
+    tags:
+    - alz
+    properties:
+      scope: Resource
+      multiResource: false
+  guid: 6cf9f172-cda6-4ed6-a95c-74ed1d2efdf8


### PR DESCRIPTION
# Overview/Summary

Adds Express Route Gateway Bits Received per Second alerts as recommended in [monitoring virtual wan](https://learn.microsoft.com/en-us/azure/virtual-wan/monitor-virtual-wan)

## This PR fixes/adds/changes/removes

1. add express route gateway bits received per second alert (too low)
2. add express route gateway bits received per second alert (too high)
